### PR TITLE
Fix situation with empty groups blocking the additionm of virtual groups.

### DIFF
--- a/action.php
+++ b/action.php
@@ -27,6 +27,9 @@ class action_plugin_virtualgroup extends DokuWiki_Action_Plugin {
         if (!isset($this->users[$_SERVER['REMOTE_USER']])) {
             return;
         }
+		if (!isset($USERINFO['grps'])) {
+			$USERINFO['grps'] = array();
+		}
         $grps = array_unique(array_merge($USERINFO['grps'],$this->users[$_SERVER['REMOTE_USER']]));
         $USERINFO['grps']       = $grps;
         $_SESSION[DOKU_COOKIE]['auth']['info']['grps'] = $grps;

--- a/action.php
+++ b/action.php
@@ -27,9 +27,9 @@ class action_plugin_virtualgroup extends DokuWiki_Action_Plugin {
         if (!isset($this->users[$_SERVER['REMOTE_USER']])) {
             return;
         }
-		if (!isset($USERINFO['grps'])) {
-			$USERINFO['grps'] = array();
-		}
+        if (!isset($USERINFO['grps'])) {
+            $USERINFO['grps'] = array();
+        }
         $grps = array_unique(array_merge($USERINFO['grps'],$this->users[$_SERVER['REMOTE_USER']]));
         $USERINFO['grps']       = $grps;
         $_SESSION[DOKU_COOKIE]['auth']['info']['grps'] = $grps;


### PR DESCRIPTION
Since the virtualgroup-groups are not added, ACLs based on them will not work.
This can happen with authad (ActiveDirectory) authentication selected in the DokuWiki.