### PR TITLE
Rename constructor to __construct for php8

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -16,7 +16,7 @@ class admin_plugin_virtualgroup extends DokuWiki_Admin_Plugin {
 
     var $data = array();
 
-    function admin_plugin_virtualgroup () {
+    function __construct () {
         global $auth;
 
         $this->setupLocale();


### PR DESCRIPTION
This fixes "Call to a member function getUserData() on null" in line 352.